### PR TITLE
chore(deps): update default registry's baseline to `b322364f06308bdd24823f9d8f03fe0cc86fd46f`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "$schema": "https://github.com/microsoft/vcpkg-tool/raw/refs/heads/main/docs/vcpkg-configuration.schema.json",
   "default-registry": {
     "kind": "builtin",
-    "baseline": "10b7a178346f3f0abef60cecd5130e295afd8da4"
+    "baseline": "b322364f06308bdd24823f9d8f03fe0cc86fd46f"
   },
   "registries": [
     {


### PR DESCRIPTION
This PR updates default registry's baseline to `b322364f06308bdd24823f9d8f03fe0cc86fd46f`.