### PR TITLE
build: wrap compiler flag checks in conditional for GNU/Clang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -23,10 +23,12 @@ set(CMAKE_VERBOSE_MAKEFILE ON)
 
 find_package(opentelemetry-cpp CONFIG REQUIRED)
 
-include(CheckCXXCompilerFlag)
-check_cxx_compiler_flag("-Wall" COMPILER_SUPPORTS_WALL)
-check_cxx_compiler_flag("-Wextra" COMPILER_SUPPORTS_WEXTRA)
-check_cxx_compiler_flag("-pedantic" COMPILER_SUPPORTS_PEDANTIC)
+if(CMAKE_COMPILER_IS_GNU OR CMAKE_COMPILER_IS_CLANG)
+    include(CheckCXXCompilerFlag)
+    check_cxx_compiler_flag("-Wall" COMPILER_SUPPORTS_WALL)
+    check_cxx_compiler_flag("-Wextra" COMPILER_SUPPORTS_WEXTRA)
+    check_cxx_compiler_flag("-pedantic" COMPILER_SUPPORTS_PEDANTIC)
+endif()
 
 if(CMAKE_CONFIGURATION_TYPES)
     list(APPEND CMAKE_CONFIGURATION_TYPES "Coverage" "ASAN" "LSAN" "TSAN" "UBSAN")


### PR DESCRIPTION
This pull request introduces a conditional check to ensure that certain compiler flags are only evaluated when using GCC or Clang compilers. This change improves compatibility and avoids unnecessary checks for unsupported compilers.

### Build system improvements:

* [`CMakeLists.txt`](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR26-R31): Wrapped the `check_cxx_compiler_flag` calls for `-Wall`, `-Wextra`, and `-pedantic` inside a conditional block to ensure they are only executed when the compiler is GCC or Clang. This prevents potential issues with other compilers.