### PR TITLE
chore(deps): update default registry's baseline to `120deac3062162151622ca4860575a33844ba10b`

### DIFF
--- a/vcpkg-configuration.json
+++ b/vcpkg-configuration.json
@@ -2,7 +2,7 @@
   "$schema": "https://github.com/microsoft/vcpkg-tool/raw/refs/heads/main/docs/vcpkg-configuration.schema.json",
   "default-registry": {
     "kind": "builtin",
-    "baseline": "dd3097e305afa53f7b4312371f62058d2e665320"
+    "baseline": "120deac3062162151622ca4860575a33844ba10b"
   },
   "registries": [
     {


### PR DESCRIPTION
This PR updates default registry's baseline to `120deac3062162151622ca4860575a33844ba10b`.